### PR TITLE
Compatible with AGP 8

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -30,6 +30,11 @@ def getExtOrIntegerDefault(name) {
 android {
   compileSdkVersion getExtOrIntegerDefault('compileSdkVersion')
 
+  def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
+  if (agpVersion.tokenize('.')[0].toInteger() >= 7) {
+    namespace "com.reactnativezview"
+  }
+
   defaultConfig {
     minSdkVersion getExtOrIntegerDefault('minSdkVersion')
     targetSdkVersion getExtOrIntegerDefault('targetSdkVersion')


### PR DESCRIPTION
React Native 0.73 will depend on Android Gradle Plugin (AGP) 8.x. This will require all the libraries to specify a `namespace` in their `build.gradle` file.